### PR TITLE
feat: add event detail page

### DIFF
--- a/book-my-show-fe/src/app/(public)/events/[eventId]/_components/event-details.tsx
+++ b/book-my-show-fe/src/app/(public)/events/[eventId]/_components/event-details.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Image from "next/image";
+import { useTRPC } from "@/trpc/client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ErrorState } from "@/components/error-state";
+
+interface Props {
+  eventId: string;
+}
+
+const EventDetails = ({ eventId }: Props) => {
+  const trpc = useTRPC();
+
+  const { data } = useSuspenseQuery(
+    trpc.events.getById.queryOptions({ eventId })
+  );
+
+  if (!data) {
+    return (
+      <ErrorState
+        title="Event not found"
+        description="The event you are looking for does not exist."
+      />
+    );
+  }
+
+  const start = new Date(data.startDate);
+  const end = new Date(data.endDate);
+  const durationMinutes = Math.round((end.getTime() - start.getTime()) / 60000);
+  const durationHours = durationMinutes / 60 || 2;
+
+  return (
+    <div className="p-8 flex flex-col gap-6">
+      <div className="relative w-full h-64">
+        <Image
+          src={data.bannerUrl}
+          alt={data.title}
+          fill
+          className="object-cover rounded-md"
+          unoptimized
+        />
+      </div>
+      <h1 className="text-2xl font-bold">{data.title}</h1>
+      <p className="text-gray-700">{data.description}</p>
+      <div className="text-sm text-gray-600 flex flex-col gap-1">
+        <p>
+          <strong>Showtime:</strong>{" "}
+          {start.toLocaleString("en-GB", {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </p>
+        <p>
+          <strong>Venue:</strong> {data.organizerName}
+        </p>
+        <p>
+          <strong>Duration:</strong> {durationHours} hours
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default EventDetails;

--- a/book-my-show-fe/src/app/(public)/events/[eventId]/page.tsx
+++ b/book-my-show-fe/src/app/(public)/events/[eventId]/page.tsx
@@ -1,0 +1,40 @@
+import { Suspense } from "react";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { ErrorBoundary } from "react-error-boundary";
+
+import { getQueryClient, trpc } from "@/trpc/server";
+import EventDetails from "./_components/event-details";
+import Loading from "@/components/loading";
+import { ErrorState } from "@/components/error-state";
+
+interface Props {
+  params: Promise<{
+    eventId: string;
+  }>;
+}
+
+const EventPage = async ({ params }: Props) => {
+  const { eventId } = await params;
+
+  const queryClient = getQueryClient();
+  void queryClient.prefetchQuery(trpc.events.getById.queryOptions({ eventId }));
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<Loading />}>
+        <ErrorBoundary
+          fallback={
+            <ErrorState
+              title="Unable to load event details"
+              description="We are having some trouble loading event details. Please try again later."
+            />
+          }
+        >
+          <EventDetails eventId={eventId} />
+        </ErrorBoundary>
+      </Suspense>
+    </HydrationBoundary>
+  );
+};
+
+export default EventPage;


### PR DESCRIPTION
## Summary
- add event details page with dynamic routing
- display showtime, venue, and duration for an event

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68c7f8eea76883279fe96d884293c110