### PR TITLE
Add Swagger documentation to backend APIs

### DIFF
--- a/book-my-show-be/pom.xml
+++ b/book-my-show-be/pom.xml
@@ -39,11 +39,18 @@
   </properties>
 
   <dependencies>
-	<!-- Spring Web Dependencies -->
-	<dependency>
-	  <groupId>org.springframework.boot</groupId>
-	  <artifactId>spring-boot-starter-web</artifactId>
-	</dependency>
+        <!-- Spring Web Dependencies -->
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- OpenAPI / Swagger UI -->
+        <dependency>
+          <groupId>org.springdoc</groupId>
+          <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+          <version>2.6.0</version>
+        </dependency>
 
 	<!-- Data JPA lib -->
 	<dependency>

--- a/book-my-show-be/src/main/java/com/bookmyshow/config/OpenApiConfig.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.bookmyshow.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI ticksyOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Ticksy Booking API")
+                        .description(
+                                "REST API documentation for the Ticksy booking platform covering movies, events, venues, showtimes, and bookings.")
+                        .version("1.0.0")
+                        .contact(new Contact().name("Ticksy Team").email("support@ticksy.app"))
+                        .license(new License().name("Apache 2.0").url("https://www.apache.org/licenses/LICENSE-2.0")))
+                .servers(List.of(new Server().url("/").description("Default")));
+    }
+}

--- a/book-my-show-be/src/main/java/com/bookmyshow/controller/BookingController.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/controller/BookingController.java
@@ -14,40 +14,80 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bookmyshow.proto.BookingProto;
 import com.bookmyshow.service.BookingService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("bookings")
 @Slf4j
+@Tag(name = "Bookings", description = "Endpoints for managing ticket bookings and reservations.")
 public class BookingController {
 
     @Autowired
     private BookingService bookingService;
 
     @PostMapping(consumes = "application/x-protobuf", produces = "application/x-protobuf")
+    @Operation(summary = "Create booking", description = "Create a new ticket booking for a showtime.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Booking created successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid booking data provided."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while creating booking.")
+    })
     public ResponseEntity<?> createBooking(@RequestBody BookingProto.CreateBookingRequest request) {
         return bookingService.createBooking(request);
     }
 
     @GetMapping(value = "{bookingId}", produces = "application/x-protobuf")
+    @Operation(summary = "Get booking", description = "Retrieve booking details by identifier.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Booking found."),
+            @ApiResponse(responseCode = "404", description = "Booking not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching booking details.")
+    })
     public ResponseEntity<?> getBookingById(@PathVariable String bookingId) {
         return bookingService.getBookingById(bookingId);
     }
 
     @GetMapping(produces = "application/x-protobuf")
+    @Operation(summary = "List user bookings", description = "Retrieve bookings for a user with optional pagination.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Bookings retrieved successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid pagination parameters supplied."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching bookings.")
+    })
     public ResponseEntity<?> listBookings(
+            @Parameter(description = "User identifier to fetch bookings for.", required = true)
             @RequestParam String userId,
+            @Parameter(description = "Optional page number for pagination.", example = "0")
             @RequestParam(required = false) Integer pageNumber,
+            @Parameter(description = "Optional page size for pagination.", example = "10")
             @RequestParam(required = false) Integer pageSize) {
         return bookingService.listBookings(userId, pageNumber, pageSize);
     }
 
     @GetMapping(value = "showtime/{showtimeId}", produces = "application/x-protobuf")
+    @Operation(summary = "List bookings for showtime", description = "Retrieve bookings for a specific showtime.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Bookings retrieved successfully."),
+            @ApiResponse(responseCode = "404", description = "Showtime not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching bookings.")
+    })
     public ResponseEntity<?> getBookingsForShowtime(@PathVariable String showtimeId) {
         return bookingService.getBookingsForShowtime(showtimeId);
     }
 
     @PatchMapping(value = "{bookingId}/status", consumes = "application/x-protobuf", produces = "application/x-protobuf")
+    @Operation(summary = "Update booking status", description = "Update the status of an existing booking.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Booking status updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid status update provided."),
+            @ApiResponse(responseCode = "404", description = "Booking not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while updating booking.")
+    })
     public ResponseEntity<?> updateBookingStatus(@PathVariable String bookingId,
             @RequestBody BookingProto.UpdateBookingStatusRequest request) {
         return bookingService.updateBookingStatus(bookingId, request);

--- a/book-my-show-be/src/main/java/com/bookmyshow/controller/DemoController.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/controller/DemoController.java
@@ -1,12 +1,17 @@
 package com.bookmyshow.controller;
 
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController()
+@Tag(name = "Health", description = "Endpoints for checking the health of the backend service.")
 public class DemoController {
 
     @GetMapping("v1")
+    @Operation(summary = "Health check", description = "Returns a friendly message indicating that the backend is operational.")
     public String getMethodName() {
         return "Ticksy -> Backend Up and Working 🎉";
     }

--- a/book-my-show-be/src/main/java/com/bookmyshow/controller/EventController.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/controller/EventController.java
@@ -1,12 +1,5 @@
 package com.bookmyshow.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.bookmyshow.proto.EventProto;
-import com.bookmyshow.service.EventService;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,43 +8,97 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bookmyshow.proto.EventProto;
+import com.bookmyshow.service.EventService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController()
 @RequestMapping("events")
+@Tag(name = "Events", description = "Endpoints for creating and managing live events and experiences.")
 public class EventController {
 
     @Autowired
     private EventService eventService;
 
     @GetMapping(produces = "application/x-protobuf")
+    @Operation(summary = "List events", description = "Retrieve events with optional filters for title, type and category.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Events retrieved successfully."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching events.")
+    })
     public ResponseEntity<?> getAllEvents(
+            @Parameter(description = "Optional case-insensitive filter on event title.", example = "Music")
             @RequestParam(required = false, defaultValue = "") String title,
+            @Parameter(description = "Optional filter based on event type.", example = "CONCERT")
             @RequestParam(required = false, defaultValue = "") String eventType,
+            @Parameter(description = "Optional filter based on category type.", example = "MUSIC")
             @RequestParam(required = false, defaultValue = "") String categoryType) {
         return eventService.getAllEvents(title, eventType, categoryType);
     }
 
     @GetMapping(value = "{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Get event", description = "Retrieve event details by identifier.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Event found."),
+            @ApiResponse(responseCode = "404", description = "Event not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching event details.")
+    })
     public ResponseEntity<?> getEventById(@PathVariable String id) {
         return eventService.getEventById(id);
     }
 
     @PostMapping(produces = "application/x-protobuf")
+    @Operation(summary = "Create event (protobuf)", description = "Create a new event using protobuf payloads.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Event created successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid event data provided."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while creating event.")
+    })
     public ResponseEntity<?> createEvent(@RequestBody EventProto.EventInput event) {
         return eventService.createEvent(event);
     }
 
     @PostMapping(value = "json")
+    @Operation(summary = "Create event (JSON)", description = "Create a new event using JSON payloads.", responses = {
+            @ApiResponse(responseCode = "200", description = "Event created successfully.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = com.bookmyshow.dto.EventInput.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid event data provided."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while creating event.")
+    })
     public ResponseEntity<?> createEventJson(@RequestBody com.bookmyshow.dto.EventInput event) {
         return eventService.createEventJson(event);
     }
 
     @PatchMapping(value = "update/{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Update event", description = "Apply partial updates to an existing event.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Event updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid event update supplied."),
+            @ApiResponse(responseCode = "404", description = "Event not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while updating event.")
+    })
     public ResponseEntity<?> updateEvent(@PathVariable String id, @RequestBody EventProto.Event event) {
         return eventService.updateEvent(id, event);
     }
 
     @DeleteMapping(value = "delete/{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Delete event", description = "Remove an event from the catalogue.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Event deleted successfully."),
+            @ApiResponse(responseCode = "404", description = "Event not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while deleting event.")
+    })
     public ResponseEntity<?> deleteEvent(@PathVariable String id) {
         return eventService.deleteEvent(id);
     }

--- a/book-my-show-be/src/main/java/com/bookmyshow/controller/MovieController.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/controller/MovieController.java
@@ -1,12 +1,5 @@
 package com.bookmyshow.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.bookmyshow.proto.MovieProto;
-import com.bookmyshow.service.MovieService;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,37 +8,82 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bookmyshow.proto.MovieProto;
+import com.bookmyshow.service.MovieService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController()
 @RequestMapping("movies")
+@Tag(name = "Movies", description = "Operations related to managing movie catalogue data.")
 public class MovieController {
 
     @Autowired
     private MovieService movieService;
 
     @GetMapping(produces = "application/x-protobuf")
+    @Operation(summary = "List movies", description = "Retrieve movies with optional filters for title and genre.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movies retrieved successfully."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching movies.")
+    })
     public ResponseEntity<?> getAllMovies(
+            @Parameter(description = "Optional case-insensitive filter on movie title.", example = "Inception")
             @RequestParam(required = false, defaultValue = "") String title,
+            @Parameter(description = "Optional filter on movie genre.", example = "ACTION")
             @RequestParam(required = false, defaultValue = "") String genre) {
         return movieService.getAllMovies(title, genre);
     }
 
     @GetMapping(value = "{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Get movie", description = "Retrieve details for a single movie by its identifier.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movie found."),
+            @ApiResponse(responseCode = "404", description = "Movie not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching movie details.")
+    })
     public ResponseEntity<?> getMovieById(@PathVariable String id) {
         return movieService.getMovieById(id);
     }
 
     @PostMapping(produces = "application/x-protobuf")
+    @Operation(summary = "Create movie", description = "Create a new movie entry in the catalogue.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movie created successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid movie data supplied."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while creating movie.")
+    })
     public ResponseEntity<?> createMovie(@RequestBody MovieProto.MovieInput movie) {
         return movieService.createMovie(movie);
     }
 
     @PatchMapping(value = "update/{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Update movie", description = "Apply partial updates to an existing movie.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movie updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid movie update supplied."),
+            @ApiResponse(responseCode = "404", description = "Movie not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while updating movie.")
+    })
     public ResponseEntity<?> updateMovie(@PathVariable String id, @RequestBody MovieProto.Movie movie) {
         return movieService.updateMovie(id, movie);
     }
 
     @DeleteMapping(value = "delete/{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Delete movie", description = "Remove a movie entry from the catalogue.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Movie deleted successfully."),
+            @ApiResponse(responseCode = "404", description = "Movie not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while deleting movie.")
+    })
     public ResponseEntity<?> deleteMovie(@PathVariable String id) {
         return movieService.deleteMovie(id);
     }

--- a/book-my-show-be/src/main/java/com/bookmyshow/controller/ShowtimeController.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/controller/ShowtimeController.java
@@ -1,52 +1,109 @@
 package com.bookmyshow.controller;
 
-import com.bookmyshow.proto.ShowtimeProto;
-import com.bookmyshow.service.ShowtimeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bookmyshow.proto.ShowtimeProto;
+import com.bookmyshow.service.ShowtimeService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("showtimes")
+@Tag(name = "Showtimes", description = "Endpoints for scheduling and querying movie showtimes.")
 public class ShowtimeController {
 
     @Autowired
     private ShowtimeService showtimeService;
 
     @GetMapping(produces = "application/x-protobuf")
+    @Operation(summary = "List showtimes", description = "Retrieve every scheduled showtime.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Showtimes retrieved successfully."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching showtimes.")
+    })
     public ResponseEntity<?> getAllShowtimes() {
         return showtimeService.getAllShowtimes();
     }
 
     @GetMapping(value = "by-movie/{movieId}", produces = "application/x-protobuf")
+    @Operation(summary = "List showtimes by movie", description = "Retrieve showtimes for a particular movie on a given date.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Showtimes retrieved successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid request parameters supplied."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching showtimes.")
+    })
     public ResponseEntity<?> getShowtimesByMovieId(@PathVariable String movieId,
+            @Parameter(description = "ISO-8601 date (yyyy-MM-dd) to filter showtimes.", example = "2024-08-21")
             @RequestParam String date) {
         return showtimeService.getShowtimesByMovieId(movieId, date);
     }
 
     @GetMapping(value = "{showtimeId}", produces = "application/x-protobuf")
+    @Operation(summary = "Get showtime", description = "Retrieve showtime details by identifier.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Showtime found."),
+            @ApiResponse(responseCode = "404", description = "Showtime not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching showtime details.")
+    })
     public ResponseEntity<?> getShowtimeById(@PathVariable String showtimeId) {
         return showtimeService.getShowtimeById(showtimeId);
     }
 
     @GetMapping(value = "booked-seats/{showtimeId}", produces = "application/x-protobuf")
+    @Operation(summary = "Get booked seats", description = "Retrieve the seats that have already been booked for a showtime.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Booked seats retrieved successfully."),
+            @ApiResponse(responseCode = "404", description = "Showtime not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching booked seats.")
+    })
     public ResponseEntity<?> getBookedSeats(@PathVariable String showtimeId) {
         return showtimeService.getBookedSeats(showtimeId);
     }
 
     @PostMapping(produces = "application/x-protobuf")
+    @Operation(summary = "Create showtime", description = "Create a new showtime schedule.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Showtime created successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid showtime data provided."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while creating showtime.")
+    })
     public ResponseEntity<?> createShowtime(@RequestBody ShowtimeProto.ShowtimeInput showtime) {
         return showtimeService.createShowtime(showtime);
     }
 
     @PatchMapping(value = "update/{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Update showtime", description = "Update an existing showtime schedule.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Showtime updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid showtime update provided."),
+            @ApiResponse(responseCode = "404", description = "Showtime not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while updating showtime.")
+    })
     public ResponseEntity<?> updateShowtime(@PathVariable String id, @RequestBody ShowtimeProto.Showtime showtime) {
         return showtimeService.updateShowtime(id, showtime);
     }
 
     @DeleteMapping(value = "delete/{id}", produces = "application/x-protobuf")
+    @Operation(summary = "Delete showtime", description = "Remove a showtime from the schedule.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Showtime deleted successfully."),
+            @ApiResponse(responseCode = "404", description = "Showtime not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while deleting showtime.")
+    })
     public ResponseEntity<?> deleteShowtime(@PathVariable String id) {
         return showtimeService.deleteShowtime(id);
     }

--- a/book-my-show-be/src/main/java/com/bookmyshow/controller/VenueController.java
+++ b/book-my-show-be/src/main/java/com/bookmyshow/controller/VenueController.java
@@ -1,43 +1,89 @@
 package com.bookmyshow.controller;
 
-import com.bookmyshow.models.Venue;
-import com.bookmyshow.service.VenueService;
-
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bookmyshow.models.Venue;
+import com.bookmyshow.service.VenueService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("venues")
+@Tag(name = "Venues", description = "Manage venue inventory and metadata.")
 public class VenueController {
 
     @Autowired
     private VenueService venueService;
 
     @GetMapping()
-    public ResponseEntity<?> getAllVenues(@Param("venueType") String venueType) {
+    @Operation(summary = "List venues", description = "Retrieve all venues with an optional filter on venue type.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Venues retrieved successfully."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching venues.")
+    })
+    public ResponseEntity<?> getAllVenues(
+            @Parameter(description = "Optional filter restricting venues by type.", example = "THEATRE")
+            @Param("venueType") String venueType) {
         return venueService.getAllVenues(Optional.ofNullable(venueType));
     }
 
     @GetMapping("{id}")
+    @Operation(summary = "Get venue", description = "Retrieve venue details by identifier.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Venue found."),
+            @ApiResponse(responseCode = "404", description = "Venue not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while fetching venue details.")
+    })
     public ResponseEntity<?> getVenueById(@PathVariable String id) {
         return venueService.getVenueById(id);
     }
 
     @PostMapping()
+    @Operation(summary = "Create venue", description = "Create a new venue record.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Venue created successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid venue data provided."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while creating venue.")
+    })
     public ResponseEntity<?> createVenue(@RequestBody Venue venue) {
         return venueService.createVenue(venue);
     }
 
     @PatchMapping("update/{id}")
+    @Operation(summary = "Update venue", description = "Update an existing venue record.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Venue updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid venue update provided."),
+            @ApiResponse(responseCode = "404", description = "Venue not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while updating venue.")
+    })
     public ResponseEntity<?> updateVenue(@PathVariable String id, @RequestBody Venue venue) {
         return venueService.updateVenue(id, venue);
     }
 
     @DeleteMapping("delete/{id}")
+    @Operation(summary = "Delete venue", description = "Remove a venue from the catalogue.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Venue deleted successfully."),
+            @ApiResponse(responseCode = "404", description = "Venue not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected error while deleting venue.")
+    })
     public ResponseEntity<?> deleteVenue(@PathVariable String id) {
         return venueService.deleteVenue(id);
     }


### PR DESCRIPTION
## Summary
- add Springdoc OpenAPI dependency and configuration for Swagger UI metadata
- annotate every backend controller with OpenAPI tags, operations, and response details
- document query parameters and request bodies for clearer API contracts

## Testing
- mvn -q verify *(fails: cannot reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfce73c76483278e14ecf1c090b161