### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/book-my-show-fe/src/app/(public)/_components/recommended-events.tsx
+++ b/book-my-show-fe/src/app/(public)/_components/recommended-events.tsx
@@ -27,7 +27,7 @@ const RecommendedEvents = () => {
             {Array.from({ length: 5 }).map((_, i) => (
               <CarouselItem
                 key={i}
-                className="h-80 bg-gray-300/30 rounded-lg animate-pulse md:basis-1/2 lg:basis-1/4"
+                className="h-64 bg-gray-300/30 rounded-lg animate-pulse md:basis-1/2 lg:basis-1/4"
               />
             ))}
           </CarouselContent>
@@ -45,53 +45,53 @@ const RecommendedEvents = () => {
       <Carousel className="w-full">
         <CarouselContent className="-ml-1 gap-4">
           {data?.map((event) => {
-            // Use logo as fallback if image is not available
-            const imageSrc = event.bannerUrl && event.bannerUrl.trim() !== "" 
-              ? event.bannerUrl 
-              : "/logo.png";
+            const imageSrc =
+              event.bannerUrl && event.bannerUrl.trim() !== ""
+                ? event.bannerUrl
+                : "/logo.png";
 
             return (
-            <CarouselItem
-              key={event.eventId}
-              className="pl-1 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4"
-            >
-              <div className="flex flex-col gap-3 rounded-2xl overflow-hidden bg-primary/10">
-                <div className="relative group">
-                  {/* Image */}
-                  <div className="relative w-full h-64 sm:h-72 md:h-80 overflow-hidden">
-                    <Image
-                      src={imageSrc}
-                      alt={event.title}
-                      fill
-                      className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
-                      unoptimized
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement;
-                        if (target.src !== "/logo.png") {
-                          target.src = "/logo.png";
-                        }
-                      }}
-                    />
-                  </div>
+              <CarouselItem
+                key={event.eventId}
+                className="pl-1 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4"
+              >
+                <div className="flex flex-col gap-3 rounded-2xl overflow-hidden bg-primary/10">
+                  <div className="relative group">
+                    {/* Image */}
+                    <div className="relative w-full h-52 sm:h-60 md:h-72 overflow-hidden">
+                      <Image
+                        src={imageSrc}
+                        alt={event.title}
+                        fill
+                        className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
+                        unoptimized
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          if (target.src !== "/logo.png") {
+                            target.src = "/logo.png";
+                          }
+                        }}
+                      />
+                    </div>
 
-                  {/* Hover Overlay with Button */}
-                  <div className="absolute inset-0 flex flex-col gap-3 items-start justify-end bg-black/40 opacity-100 transition-opacity duration-300 px-4 py-4">
-                    <h3 className="text-white text-md font-semibold text-start">
-                      {event.title}
-                    </h3>
-                    <p className=" text-xs text-white line-clamp-3">
-                      {event.description.slice(0, 80)}...
-                    </p>
-                    <Link
-                      href={`/events/${event.eventId}`}
-                      className="px-4 py-1 bg-primary/70 text-white text-xs font-medium rounded-sm shadow hover:bg-primary/10"
-                    >
-                      Book Now
-                    </Link>
+                    {/* Hover Overlay with Button */}
+                    <div className="absolute inset-0 flex flex-col gap-2 items-start justify-end bg-black/40 opacity-100 transition-opacity duration-300 px-3 py-3">
+                      <h3 className="text-white text-sm sm:text-base font-semibold text-start line-clamp-1">
+                        {event.title}
+                      </h3>
+                      <p className="text-[11px] sm:text-xs text-white line-clamp-2">
+                        {event.description}
+                      </p>
+                      <Link
+                        href={`/events/${event.eventId}`}
+                        className="px-3 py-1 bg-primary/70 text-white text-xs font-medium rounded-sm shadow hover:bg-primary/10"
+                      >
+                        Book Now
+                      </Link>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </CarouselItem>
+              </CarouselItem>
             );
           })}
         </CarouselContent>

--- a/book-my-show-fe/src/app/(public)/_components/recommended-movies.tsx
+++ b/book-my-show-fe/src/app/(public)/_components/recommended-movies.tsx
@@ -26,7 +26,7 @@ const RecommendedMovies = () => {
             {Array.from({ length: 5 }).map((_, i) => (
               <CarouselItem
                 key={i}
-                className="h-80 bg-gray-300/30 rounded-lg animate-pulse md:basis-1/2 lg:basis-1/4"
+                className="h-64 bg-gray-300/30 rounded-lg animate-pulse md:basis-1/2 lg:basis-1/4"
               />
             ))}
           </CarouselContent>
@@ -44,53 +44,53 @@ const RecommendedMovies = () => {
       <Carousel className="w-full">
         <CarouselContent className="-ml-1 gap-4">
           {data?.map((movie) => {
-            // Use logo as fallback if image is not available
-            const imageSrc = movie.imageKey && movie.imageKey.trim() !== "" 
-              ? movie.imageKey 
-              : "/logo.png";
+            const imageSrc =
+              movie.imageKey && movie.imageKey.trim() !== ""
+                ? movie.imageKey
+                : "/logo.png";
 
             return (
-            <CarouselItem
-              key={movie.movieId}
-              className="pl-1 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4"
-            >
-              <div className="flex flex-col gap-3 rounded-2xl overflow-hidden bg-primary/10">
-                <div className="relative group">
-                  {/* Image */}
-                  <div className="relative w-full h-64 sm:h-72 md:h-80 overflow-hidden">
-                    <Image
-                      src={imageSrc}
-                      alt={movie.title}
-                      fill
-                      className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
-                      unoptimized
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement;
-                        if (target.src !== "/logo.png") {
-                          target.src = "/logo.png";
-                        }
-                      }}
-                    />
-                  </div>
+              <CarouselItem
+                key={movie.movieId}
+                className="pl-1 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4"
+              >
+                <div className="flex flex-col gap-3 rounded-2xl overflow-hidden bg-primary/10">
+                  <div className="relative group">
+                    {/* Image */}
+                    <div className="relative w-full h-52 sm:h-60 md:h-72 overflow-hidden">
+                      <Image
+                        src={imageSrc}
+                        alt={movie.title}
+                        fill
+                        className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
+                        unoptimized
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          if (target.src !== "/logo.png") {
+                            target.src = "/logo.png";
+                          }
+                        }}
+                      />
+                    </div>
 
-                  {/* Hover Overlay with Button */}
-                  <div className="absolute inset-0 flex flex-col gap-3 items-start justify-end bg-black/40 opacity-100 transition-opacity duration-300 px-4 py-4">
-                    <h3 className="text-white text-md font-semibold text-start">
-                      {movie.title.slice(0, 30)}...
-                    </h3>
-                    <p className=" text-xs text-white line-clamp-3 ">
-                      {movie.description.slice(0, 80)}...
-                    </p>
-                    <Link
-                      href={`/movies/${movie.movieId}`}
-                      className="px-4 py-1 bg-primary/70 text-white text-xs font-medium rounded-sm shadow hover:bg-primary/10"
-                    >
-                      Book Now
-                    </Link>
+                    {/* Hover Overlay with Button */}
+                    <div className="absolute inset-0 flex flex-col gap-2 items-start justify-end bg-black/40 opacity-100 transition-opacity duration-300 px-3 py-3">
+                      <h3 className="text-white text-sm sm:text-base font-semibold text-start line-clamp-1">
+                        {movie.title}
+                      </h3>
+                      <p className="text-[11px] sm:text-xs text-white line-clamp-2">
+                        {movie.description}
+                      </p>
+                      <Link
+                        href={`/movies/${movie.movieId}`}
+                        className="px-3 py-1 bg-primary/70 text-white text-xs font-medium rounded-sm shadow hover:bg-primary/10"
+                      >
+                        Book Now
+                      </Link>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </CarouselItem>
+              </CarouselItem>
             );
           })}
         </CarouselContent>

--- a/book-my-show-fe/src/app/(public)/_components/recommended-sports.tsx
+++ b/book-my-show-fe/src/app/(public)/_components/recommended-sports.tsx
@@ -29,7 +29,7 @@ const RecommendedSports = ({}: Props) => {
             {Array.from({ length: 5 }).map((_, i) => (
               <CarouselItem
                 key={i}
-                className="h-80 bg-gray-300/30 rounded-lg animate-pulse md:basis-1/2 lg:basis-1/4"
+                className="h-64 bg-gray-300/30 rounded-lg animate-pulse md:basis-1/2 lg:basis-1/4"
               />
             ))}
           </CarouselContent>
@@ -47,53 +47,53 @@ const RecommendedSports = ({}: Props) => {
       <Carousel className="w-full">
         <CarouselContent className="-ml-1 gap-4">
           {data?.map((event) => {
-            // Use logo as fallback if image is not available
-            const imageSrc = event.bannerUrl && event.bannerUrl.trim() !== "" 
-              ? event.bannerUrl 
-              : "/logo.png";
+            const imageSrc =
+              event.bannerUrl && event.bannerUrl.trim() !== ""
+                ? event.bannerUrl
+                : "/logo.png";
 
             return (
-            <CarouselItem
-              key={event.eventId}
-              className="pl-1 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4"
-            >
-              <div className="flex flex-col gap-3 rounded-2xl overflow-hidden bg-primary/10">
-                <div className="relative group">
-                  {/* Image */}
-                  <div className="relative w-full h-64 sm:h-72 md:h-80 overflow-hidden">
-                    <Image
-                      src={imageSrc}
-                      alt={event.title}
-                      fill
-                      className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
-                      unoptimized
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement;
-                        if (target.src !== "/logo.png") {
-                          target.src = "/logo.png";
-                        }
-                      }}
-                    />
-                  </div>
+              <CarouselItem
+                key={event.eventId}
+                className="pl-1 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4"
+              >
+                <div className="flex flex-col gap-3 rounded-2xl overflow-hidden bg-primary/10">
+                  <div className="relative group">
+                    {/* Image */}
+                    <div className="relative w-full h-52 sm:h-60 md:h-72 overflow-hidden">
+                      <Image
+                        src={imageSrc}
+                        alt={event.title}
+                        fill
+                        className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
+                        unoptimized
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          if (target.src !== "/logo.png") {
+                            target.src = "/logo.png";
+                          }
+                        }}
+                      />
+                    </div>
 
-                  {/* Hover Overlay with Button */}
-                  <div className="absolute inset-0 flex flex-col gap-3 items-start justify-end bg-black/40 opacity-100 transition-opacity duration-300 px-4 py-4">
-                    <h3 className="text-white text-md font-semibold text-start">
-                      {event.title.slice(0, 30)}...
-                    </h3>
-                    <p className=" text-xs text-white line-clamp-3">
-                      {event.description.slice(0, 80)}...
-                    </p>
-                    <Link
-                      href={`/events/${event.eventId}`}
-                      className="px-4 py-1 bg-primary/70 text-white text-xs font-medium rounded-sm shadow hover:bg-primary/10"
-                    >
-                      Book Now
-                    </Link>
+                    {/* Hover Overlay with Button */}
+                    <div className="absolute inset-0 flex flex-col gap-2 items-start justify-end bg-black/40 opacity-100 transition-opacity duration-300 px-3 py-3">
+                      <h3 className="text-white text-sm sm:text-base font-semibold text-start line-clamp-1">
+                        {event.title}
+                      </h3>
+                      <p className="text-[11px] sm:text-xs text-white line-clamp-2">
+                        {event.description}
+                      </p>
+                      <Link
+                        href={`/events/${event.eventId}`}
+                        className="px-3 py-1 bg-primary/70 text-white text-xs font-medium rounded-sm shadow hover:bg-primary/10"
+                      >
+                        Book Now
+                      </Link>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </CarouselItem>
+              </CarouselItem>
             );
           })}
         </CarouselContent>

--- a/book-my-show-fe/src/app/(public)/sports/_components/header.tsx
+++ b/book-my-show-fe/src/app/(public)/sports/_components/header.tsx
@@ -51,18 +51,20 @@ const EventHeader = () => {
   };
 
   return (
-    <div className="">
-      <div className="container mx-auto px-4 py-6">
-        <h1 className="text-3xl font-bold text-gray-800 mb-4">Sports</h1>
+    <div>
+      <div className="container mx-auto px-3 sm:px-4 md:px-6 py-4 sm:py-6">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-800 mb-3 sm:mb-4">
+          Sports
+        </h1>
 
         {/* Search and Filters */}
-        <div className="flex gap-4 justify-between py-2">
+        <div className="flex flex-col gap-3 sm:gap-4 py-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap gap-2">
             {categories.map((category) => (
               <button
                 key={category}
                 onClick={() => handleCategoryFilter(category)}
-                className={`px-4 py-0 rounded-full h-8 text-xs transition-colors ${
+                className={`px-3 sm:px-4 py-0 rounded-full h-7 sm:h-8 text-[10px] sm:text-xs transition-colors ${
                   categoryFilter === category
                     ? "bg-primary text-white"
                     : "bg-gray-200 text-gray-700 hover:bg-gray-300"
@@ -73,14 +75,14 @@ const EventHeader = () => {
             ))}
           </div>
 
-          <div className="relative w-[400px]">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
+          <div className="relative w-full sm:w-[280px] md:w-[360px] lg:w-[420px]">
+            <Search className="absolute left-2 sm:left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4 sm:w-5 sm:h-5" />
             <Input
               type="text"
               placeholder="Search sports..."
               value={searchTerm}
               onChange={(e) => handleSearchChange(e.target.value)}
-              className="pl-10"
+              className="pl-8 sm:pl-10 text-sm sm:text-base"
             />
           </div>
         </div>

--- a/book-my-show-fe/src/app/globals.css
+++ b/book-my-show-fe/src/app/globals.css
@@ -141,7 +141,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }
 

--- a/book-my-show-fe/src/components/ui/carousel.tsx
+++ b/book-my-show-fe/src/components/ui/carousel.tsx
@@ -187,7 +187,7 @@ function CarouselPrevious({
       className={cn(
         "absolute size-8 rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
+          ? "top-1/2 left-3 -translate-y-1/2 sm:left-4 md:left-6"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
         className
       )}
@@ -217,7 +217,7 @@ function CarouselNext({
       className={cn(
         "absolute size-8 rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
+          ? "top-1/2 right-3 -translate-y-1/2 sm:right-4 md:right-6"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
         className
       )}


### PR DESCRIPTION
## Summary
- prevent horizontal overflow globally to reduce mobile scrolling issues
- update the sports page header to stack filters and search cleanly on smaller screens with responsive input widths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec73238388327abf93366736720a9)